### PR TITLE
[lint] fix warnings from eslint

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/FlameGraph.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceTimelineViewer/SpanDetail/FlameGraph.tsx
@@ -58,7 +58,7 @@ const FlameGraph = ({ url, type }: IProps) => {
     };
 
     fetchFlameGraphData();
-  }, []);
+  }, [url, type]);
 
   return (
     <div


### PR DESCRIPTION
When running a version of this example on my dev Honeycomb tree, I get a warning saying useEffect hasn't captured all its dependencies. We need to explicitly declare them.